### PR TITLE
Add admin notifications, better stats and intro

### DIFF
--- a/routes/admin/menu.js
+++ b/routes/admin/menu.js
@@ -47,7 +47,8 @@ module.exports = (bot) => {
 👤 *Usuario:* ${ticket.user_name || 'N/A'}
 📍 *País:* ${ticket.pais || 'N/A'}
 🏗️ *Obra:* ${ticket.obra || 'N/A'}
-💰 *Total:* ${ticket.total || 'N/A'} (${ticket.currency || 'N/A'})
+💰 *Total:* ${ticket.total || 'N/A'} (${ticket.currency || 'N/A'})` +
+            (ticket.total_eur ? ` (~${ticket.total_eur} EUR)` : '') + `
 🕒 *Fecha:* ${new Date(ticket.createdAt).toLocaleString('es-ES')}`;
 
           if (ticket.image) {
@@ -81,7 +82,11 @@ module.exports = (bot) => {
 
     if (data === 'admin_stats') {
       const stats = await getStats();
-      await bot.sendMessage(chatId, `📊 Tickets registrados: ${stats.totalTickets}`);
+      let msgStats = `📊 Tickets registrados: ${stats.totalTickets}`;
+      if (stats.totalEUR !== undefined) {
+        msgStats += `\n💶 Gasto total aproximado: ${stats.totalEUR} EUR`;
+      }
+      await bot.sendMessage(chatId, msgStats);
       await bot.answerCallbackQuery({ callback_query_id: query.id });
     }
   });
@@ -101,7 +106,8 @@ module.exports = (bot) => {
 👤 *Usuario:* ${ticket.user_name || 'N/A'}
 📍 *País:* ${ticket.pais || 'N/A'}
 🏗️ *Obra:* ${ticket.obra || 'N/A'}
-💰 *Total:* ${ticket.total || 'N/A'} (${ticket.currency || 'N/A'})
+💰 *Total:* ${ticket.total || 'N/A'} (${ticket.currency || 'N/A'})` +
+          (ticket.total_eur ? ` (~${ticket.total_eur} EUR)` : '') + `
 🕒 *Fecha:* ${new Date(ticket.createdAt).toLocaleString('es-ES')}`;
 
         if (ticket.image) {

--- a/routes/admin/viewTickets.js
+++ b/routes/admin/viewTickets.js
@@ -1,4 +1,4 @@
-const { getLastTickets } = require('../../services/db');
+const { getLastTickets, getTicketById } = require('../../services/db');
 
 module.exports = (bot) => {
   bot.onText(/^\/admin_tickets$/, async (msg) => {
@@ -17,7 +17,8 @@ module.exports = (bot) => {
 👤 *Usuario:* ${ticket.user_name || 'N/A'}
 📍 *País:* ${ticket.pais || 'N/A'}
 🏗️ *Obra:* ${ticket.obra || 'N/A'}
-💰 *Total:* ${ticket.total || 'N/A'} (${ticket.currency || 'N/A'})
+💰 *Total:* ${ticket.total || 'N/A'} (${ticket.currency || 'N/A'})` +
+          (ticket.total_eur ? ` (~${ticket.total_eur} EUR)` : '') + `
 🕒 *Fecha:* ${ticket.date || 'N/A'} - ${ticket.time || ''}
 📅 *Creado:* ${new Date(ticket.createdAt).toLocaleString('es-ES')}`;
 
@@ -34,5 +35,40 @@ module.exports = (bot) => {
       console.error('❌ Error mostrando tickets:', err.message);
       await bot.sendMessage(chatId, '⚠️ Error al recuperar los tickets.');
     }
+  });
+
+  // Mostrar un ticket específico cuando llega la notificación
+  bot.on('callback_query', async (query) => {
+    const data = query.data;
+    if (!data.startsWith('admin_view_ticket_')) return;
+
+    const chatId = query.message.chat.id;
+    const id = parseInt(data.split('_').pop());
+    const ticket = await getTicketById(id);
+
+    if (!ticket) {
+      await bot.sendMessage(chatId, '❌ Ticket no encontrado.');
+      return bot.answerCallbackQuery({ callback_query_id: query.id });
+    }
+
+    const resumen = `🎟️ *Ticket ID:* ${ticket.id}\n` +
+      `👤 *Usuario:* ${ticket.user_name || 'N/A'}\n` +
+      `📍 *País:* ${ticket.pais || 'N/A'}\n` +
+      `🏗️ *Obra:* ${ticket.obra || 'N/A'}\n` +
+      `💰 *Total:* ${ticket.total || 'N/A'} (${ticket.currency || 'N/A'})` +
+      (ticket.total_eur ? ` (~${ticket.total_eur} EUR)` : '') + '\n' +
+      `🕒 *Fecha:* ${ticket.date || 'N/A'} - ${ticket.time || ''}` + '\n' +
+      `📅 *Creado:* ${new Date(ticket.createdAt).toLocaleString('es-ES')}`;
+
+    if (ticket.image) {
+      await bot.sendPhoto(chatId, Buffer.from(ticket.image, 'base64'), {
+        caption: resumen,
+        parse_mode: 'Markdown'
+      });
+    } else {
+      await bot.sendMessage(chatId, resumen, { parse_mode: 'Markdown' });
+    }
+
+    await bot.answerCallbackQuery({ callback_query_id: query.id });
   });
 };

--- a/routes/editHandler.js
+++ b/routes/editHandler.js
@@ -1,5 +1,6 @@
 const { convertToEUR, extractAmount } = require('../services/exchange');
-const { updateTicketFinal } = require('../services/db');
+const { updateTicketFinal, getTicketById } = require('../services/db');
+const { notifyAdmins } = require('../services/notifications');
 
 module.exports = (bot, sessions) => {
   // Botón de editar
@@ -44,6 +45,10 @@ module.exports = (bot, sessions) => {
       });
 
       await bot.sendMessage(chatId, '✅ Ticket guardado correctamente. ¡Gracias!');
+
+      const ticket = await getTicketById(ticketId);
+      notifyAdmins(bot, ticket);
+
       delete sessions[chatId];
       await bot.answerCallbackQuery({ callback_query_id: query.id });
     }

--- a/routes/start.js
+++ b/routes/start.js
@@ -1,7 +1,14 @@
+const { adminIds } = require('../config/admins');
+
 module.exports = (bot, sessions) => {
   const sendStartMessage = (chatId) => {
     sessions[chatId] = { step: 'start' };
-    bot.sendMessage(chatId, '👋 Hola, ¿desea subir un ticket?', {
+
+    const greeting = adminIds.includes(chatId)
+      ? '👋 ¡Hola administrador! Usa /admin para acceder al panel.\n¿Deseas subir un ticket ahora?'
+      : '👋 ¡Hola! Bienvenido al bot de tickets. Puedes registrar tus compras aquí.\n¿Deseas subir un ticket?';
+
+    bot.sendMessage(chatId, greeting, {
       reply_markup: {
         inline_keyboard: [
           [

--- a/services/db.js
+++ b/services/db.js
@@ -79,7 +79,11 @@ async function deleteTicketById(id) {
 
 async function getStats() {
   const totalTickets = await Ticket.count();
-  return { totalTickets };
+  const totalEUR = await Ticket.sum('total_eur');
+  return {
+    totalTickets,
+    totalEUR: totalEUR ? parseFloat(totalEUR.toFixed(2)) : 0
+  };
 }
 
 module.exports = {

--- a/services/notifications.js
+++ b/services/notifications.js
@@ -1,0 +1,18 @@
+const { adminIds } = require('../config/admins');
+
+// Envía una notificación a todos los administradores con opción a ver el ticket
+function notifyAdmins(bot, ticket) {
+  if (!ticket) return;
+  for (const id of adminIds) {
+    bot.sendMessage(id, `📩 Nuevo ticket recibido de *${ticket.user_name || 'usuario'}*.`, {
+      parse_mode: 'Markdown',
+      reply_markup: {
+        inline_keyboard: [
+          [{ text: 'Ver Ticket', callback_data: `admin_view_ticket_${ticket.id}` }]
+        ]
+      }
+    });
+  }
+}
+
+module.exports = { notifyAdmins };


### PR DESCRIPTION
## Summary
- improve first-time /start message for users and admins
- send a notification to admins each time a ticket is confirmed
- allow admins to open the ticket from that notification
- show totals in euros in admin views
- add total spent stats

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6846b26dc04483219b72ffdbb3ae79fc